### PR TITLE
Missing API key raises the following exception

### DIFF
--- a/lib/web_purifex.ex
+++ b/lib/web_purifex.ex
@@ -27,6 +27,6 @@ defmodule WebPurifex do
   end
 
   defp get_api_key() do[]
-    Application.get_env(:web_purifex, :api_key)
+    Application.fetch_env!(:web_purifex, :api_key)
   end
 end


### PR DESCRIPTION
We should handle this gracefully.

** (FunctionClauseError) no function clause matching in WebPurifex.Parser.do_parse/2

    The following arguments were given to WebPurifex.Parser.do_parse/2:

        # 1
        %{"rsp" => false}

        # 2
        :any_action

    Attempted function clauses (showing 2 out of 2):

        defp do_parse(%{"rsp" => %{"@attributes" => %{"stat" => "fail"}}} = response_body, _action)
        defp do_parse(%{"rsp" => %{"@attributes" => %{"stat" => "ok"}}} = response_body, _action)

    (web_purifex) lib/web_purifex/parser.ex:18: WebPurifex.Parser.do_parse/2
    (elixir) lib/enum.ex:1294: Enum."-map/2-lists^map/1-0-"/2
    (elixir) lib/enum.ex:1294: Enum."-map/2-lists^map/1-0-"/2
    (channel_advisor) lib/mix/trial_profantity_filter.ex:12: anonymous fn/0 in Mix.Tasks.ChannelAdvisor.TrailProfantityFilter.run/1
    (mix) lib/mix/task.ex:314: Mix.Task.run_task/3
    (mix) lib/mix/cli.ex:80: Mix.CLI.run_task/2