### PR TITLE
Conditionally configure test env

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -21,13 +21,13 @@ use Mix.Config
 #     config :logger, level: :info
 #
 
-# It is also possible to import configuration files, relative to this
-# directory. For example, you can emulate configuration per environment
-# by uncommenting the line below and defining dev.exs, test.exs and such.
-# Configuration from the imported file will override the ones defined
-# here (which is why it is important to import them last).
-#
-import_config "#{Mix.env}.exs"
-
+if Mix.env == :test do
+  config :exvcr, [
+    filter_sensitive_data: [
+      [pattern: "api_key=.+\&", placeholder: "API_KEY&"],
+      [pattern: "\"api_key\":\".+\"", placeholder: "\"api_key\":\"API_KEY\""]
+    ]
+  ]
+end
 
 config :web_purifex, api_key: System.get_env("WEB_PURIFY_API_KEY")

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,8 +1,0 @@
-use Mix.Config
-
-config :exvcr, [
-  filter_sensitive_data: [
-    [pattern: "api_key=.+\&", placeholder: "API_KEY&"],
-    [pattern: "\"api_key\":\".+\"", placeholder: "\"api_key\":\"API_KEY\""]
-  ]
-]


### PR DESCRIPTION
- The current config was not working with mix test.watch which starts up with the dev env.
- Now we don't have to worry about other environments this might be compiled under