### PR TITLE
Adds support for the "return" method

### DIFF
--- a/fixture/vcr_cassettes/return_multiple_profanity.json
+++ b/fixture/vcr_cassettes/return_multiple_profanity.json
@@ -1,0 +1,27 @@
+[
+  {
+    "request": {
+      "body": "method=webpurify.live.return&text=profanity_1+profanity_2&API_KEY&format=json",
+      "headers": [],
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "http://api1.webpurify.com/services/rest/"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"rsp\":{\"@attributes\":{\"stat\":\"ok\"},\"method\":\"webpurify.live.return\",\"format\":\"rest\",\"found\":\"2\",\"expletive\":[\"profanity_1\",\"profanity_2\"],\"api_key\":\"API_KEY\"}}",
+      "headers": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Mar 2018 20:07:19 GMT",
+        "Server": "nginx/1.10.3 (Ubuntu)",
+        "Vary": "Accept-Encoding",
+        "X-Powered-By": "HHVM/3.21.0",
+        "Content-Length": "171",
+        "Connection": "keep-alive"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/fixture/vcr_cassettes/return_single_profanity.json
+++ b/fixture/vcr_cassettes/return_single_profanity.json
@@ -1,0 +1,27 @@
+[
+  {
+    "request": {
+      "body": "method=webpurify.live.return&text=profanity&API_KEY&format=json",
+      "headers": [],
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "http://api1.webpurify.com/services/rest/"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"rsp\":{\"@attributes\":{\"stat\":\"ok\"},\"method\":\"webpurify.live.return\",\"format\":\"rest\",\"found\":\"1\",\"expletive\":\"profanity\",\"api_key\":\"API_KEY\"}}",
+      "headers": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Mar 2018 19:58:17 GMT",
+        "Server": "nginx/1.10.3 (Ubuntu)",
+        "Vary": "Accept-Encoding",
+        "X-Powered-By": "HHVM/3.21.0",
+        "Content-Length": "162",
+        "Connection": "keep-alive"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/fixture/vcr_cassettes/return_zero_profanity.json
+++ b/fixture/vcr_cassettes/return_zero_profanity.json
@@ -1,0 +1,27 @@
+[
+  {
+    "request": {
+      "body": "method=webpurify.live.return&text=%3asane_word%3a&API_KEY&format=json",
+      "headers": [],
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "http://api1.webpurify.com/services/rest/"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"rsp\":{\"@attributes\":{\"stat\":\"ok\"},\"method\":\"webpurify.live.return\",\"format\":\"rest\",\"found\":\"0\",\"api_key\":\"API_KEY\"}}",
+      "headers": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Mar 2018 20:25:49 GMT",
+        "Server": "nginx/1.10.3 (Ubuntu)",
+        "Vary": "Accept-Encoding",
+        "X-Powered-By": "HHVM/3.21.0",
+        "Content-Length": "143",
+        "Connection": "keep-alive"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/lib/web_purifex/parser.ex
+++ b/lib/web_purifex/parser.ex
@@ -31,7 +31,11 @@ defmodule WebPurifex.Parser do
       |> Kernel.||("0")
       |> String.to_integer
 
-    {:ok, %Response{status: status, found: found}}
+    expletive =
+      response_body
+      |> get_in(["rsp", "expletive"])
+
+    {:ok, %Response{status: status, found: found, expletive: expletive}}
   end
 
   defp build_client_error(%{"@attributes" => %{"code" => code, "msg" => message}}) do

--- a/lib/web_purifex/parser.ex
+++ b/lib/web_purifex/parser.ex
@@ -34,6 +34,7 @@ defmodule WebPurifex.Parser do
     expletive =
       response_body
       |> get_in(["rsp", "expletive"])
+      |> List.wrap
 
     {:ok, %Response{status: status, found: found, expletive: expletive}}
   end

--- a/lib/web_purifex/profanity_filter.ex
+++ b/lib/web_purifex/profanity_filter.ex
@@ -13,6 +13,10 @@ defmodule WebPurifex.ProfanityFilter do
     ProfanityFilter.CheckText.new(text)
   end
 
+  def return_text(text) do
+    ProfanityFilter.ReturnText.new(text)
+  end
+
   def whitelist(word) do
     ProfanityFilter.Whitelist.Add.new(word)
   end

--- a/lib/web_purifex/profanity_filter/return_text.ex
+++ b/lib/web_purifex/profanity_filter/return_text.ex
@@ -1,0 +1,14 @@
+defmodule WebPurifex.ProfanityFilter.ReturnText do
+  defstruct [:form_data]
+
+  @method "webpurify.live.return"
+
+  def new(text) do
+    %__MODULE__{
+      form_data: [
+        {"method", @method},
+        {"text", text}
+      ]
+    }
+  end
+end

--- a/lib/web_purifex/response.ex
+++ b/lib/web_purifex/response.ex
@@ -1,5 +1,5 @@
 defmodule WebPurifex.Response do
-  defstruct [:status, :found]
+  defstruct [:status, :found, :expletive]
 
   @type t :: %__MODULE__{}
 end

--- a/test/web_purifex/profanity_filter_test.exs
+++ b/test/web_purifex/profanity_filter_test.exs
@@ -62,7 +62,7 @@ defmodule WebPurifex.ProfanityFilterTest do
           |> ProfanityFilter.return_text
           |> WebPurifex.request
 
-        assert %Response{status: :ok, found: 0, expletive: nil} = response
+        assert %Response{status: :ok, found: 0, expletive: []} = response
       end
     end
 
@@ -73,7 +73,7 @@ defmodule WebPurifex.ProfanityFilterTest do
           |> ProfanityFilter.return_text
           |> WebPurifex.request
 
-        assert %Response{status: :ok, found: 1, expletive: "profanity"} = response
+        assert %Response{status: :ok, found: 1, expletive: ~w(profanity)} = response
       end
     end
 

--- a/test/web_purifex/profanity_filter_test.exs
+++ b/test/web_purifex/profanity_filter_test.exs
@@ -65,6 +65,17 @@ defmodule WebPurifex.ProfanityFilterTest do
         assert %Response{status: :ok, found: 1, expletive: "profanity"} = response
       end
     end
+
+    test "returns multiple strings considered profanity" do
+      use_cassette "return_multiple_profanity" do
+        {:ok, response} =
+          "profanity_1 profanity_2"
+          |> ProfanityFilter.return_text
+          |> WebPurifex.request
+
+        assert %Response{status: :ok, found: 2, expletive: ~w(profanity_1 profanity_2)} = response
+      end
+    end
   end
 
   describe "whitelisting a word" do

--- a/test/web_purifex/profanity_filter_test.exs
+++ b/test/web_purifex/profanity_filter_test.exs
@@ -54,6 +54,19 @@ defmodule WebPurifex.ProfanityFilterTest do
     end
   end
 
+  describe "returning expletives" do
+    test "returns single string considered profanity" do
+      use_cassette "return_single_profanity" do
+        {:ok, response} =
+          "profanity"
+          |> ProfanityFilter.return_text
+          |> WebPurifex.request
+
+        assert %Response{status: :ok, found: 1, expletive: "profanity"} = response
+      end
+    end
+  end
+
   describe "whitelisting a word" do
     test "adds a word to the whitelist" do
       use_cassette "whitelist_profanity" do

--- a/test/web_purifex/profanity_filter_test.exs
+++ b/test/web_purifex/profanity_filter_test.exs
@@ -55,6 +55,17 @@ defmodule WebPurifex.ProfanityFilterTest do
   end
 
   describe "returning expletives" do
+    test "returns no strings for text without profanity" do
+      use_cassette "return_zero_profanity" do
+        {:ok, response} =
+          ":sane_word:"
+          |> ProfanityFilter.return_text
+          |> WebPurifex.request
+
+        assert %Response{status: :ok, found: 0, expletive: nil} = response
+      end
+    end
+
     test "returns single string considered profanity" do
       use_cassette "return_single_profanity" do
         {:ok, response} =


### PR DESCRIPTION
https://www.webpurify.com/documentation/methods/return/

Currently, the base is of #4  as I needed this to have `mix test.watch` running.